### PR TITLE
Potential fix for code scanning alert no. 17: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,7 +149,8 @@ def delete_file():
             os.remove(file_path)
             return jsonify({"status": "success", "message": "File deleted successfully"})
         except Exception as e:
-            return jsonify({"status": "error", "message": f'{str(e)} 111'}), 500
+            app.logger.error(f"Error deleting file {file_name}: {str(e)}")
+            return jsonify({"status": "error", "message": "An internal error has occurred"}), 500
     else:
         return jsonify({"status": "error", "message": "File not found"}), 404
 
@@ -174,7 +175,8 @@ def delete_files():
                 os.remove(file_path)
                 success_files.append(file_name)
             except Exception as e:
-                failed_files.append({"file": file_name, "error": str(e)})
+                app.logger.error(f"Error deleting file {file_name}: {str(e)}")
+                failed_files.append({"file": file_name, "error": "An internal error has occurred"})
         else:
             failed_files.append({"file": file_name, "error": "File not found"})
 


### PR DESCRIPTION
Potential fix for [https://github.com/Colinm1215/MassDEPGQP/security/code-scanning/17](https://github.com/Colinm1215/MassDEPGQP/security/code-scanning/17)

To fix the problem, we should avoid sending detailed exception messages to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

We will modify the `delete_file` and `delete_files` functions to log the exception details and return a generic error message to the user. We will use Python's built-in `logging` module to log the exceptions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
